### PR TITLE
merge references file from master and Determinants_Ant_Species_Densit…

### DIFF
--- a/Determinants_ant_diversity.qmd
+++ b/Determinants_ant_diversity.qmd
@@ -3,7 +3,7 @@ title: "Determinants of Ant Species Density"
 autor: "Gabriel-Marie Arnault, Giuliana Brambilla, Apolline Byrdy, Anaelle Hulbert, Manon Le Bihan, Kilian Prevost, Chloé Van der Swaelmen and Léa Vuille"
 source : "Yannick Outreman, based on data from Gotelli & Ellison (2002) - Biogeography at a regional scale : determinants of ant species density in New England bogs and forests. Ecology, 83 : 1604-1609."
 editor: visual
-bibliography: references_determinant_ant_diversity.bib
+bibliography: references.bib
 ---
 
 # INTRODUCTION

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,10 @@
+@article{1,
+  title={A Morphometric Model to Predict the Sex of Virginia Rails (Rallus limicola)},
+  author={A.M.V. FOURNIER, M.C. SHEILDCASTLE, A.C. FRIES, J.K. BUMP},
+  year={2013},
+  publisher={Wildlife Society Bulletin}
+}
+
 
 @article{Gotelli_2002,
 	title = {Biogeography at a regional scale : determinants of ant species density in New England bogs and forests},


### PR DESCRIPTION
I propose the easiest way to fix it. As references.bib was a common file, and you change its name in your branch but it is not change in master, git merge references.bib from master with your newly named references_determinant_ant_diversity.bib . by doing so references.bib is now missing but is used by other groups too. 

the easiest way, with less side effect consists in going back to its original name after carefully check the merge between the two references files and change in your qmd the bibliography file.

That what I have done in this version. If you agree juste accept my pull request once we are sure that the checks are ok.