### PR TITLE
folding the code in Determinants_ant_diversity

### DIFF
--- a/Determinants_ant_diversity.qmd
+++ b/Determinants_ant_diversity.qmd
@@ -4,6 +4,10 @@ autor: "Gabriel-Marie Arnault, Giuliana Brambilla, Apolline Byrdy, Anaelle Hulbe
 source : "Yannick Outreman, based on data from Gotelli & Ellison (2002) - Biogeography at a regional scale : determinants of ant species density in New England bogs and forests. Ecology, 83 : 1604-1609."
 editor: visual
 bibliography: references.bib
+format: 
+  html:
+    code-fold: true
+    code-tools: true
 ---
 
 # INTRODUCTION


### PR DESCRIPTION
I add two options to facilitate the reading of our chapter: 

1. **code-fold: true** 
everytime there is a chunck, the reader can choose to see or not see the code. 

2. **code-tools: true** 
at the begining of the chapter (topright), the reader can choose to show or hide all the code.

These two options make the chapetr easier to read but the code is still available for the one that need it (as it is a R lesson). 

What do you think ? 